### PR TITLE
대표 도메인(유저, 질문 게시글,댓글, 시간, 유저 Auditing) 구현

### DIFF
--- a/src/main/java/com/example/askme/AskmeApplication.java
+++ b/src/main/java/com/example/askme/AskmeApplication.java
@@ -2,12 +2,13 @@ package com.example.askme;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class AskmeApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(AskmeApplication.class, args);
     }
-
 }

--- a/src/main/java/com/example/askme/domain/Article.java
+++ b/src/main/java/com/example/askme/domain/Article.java
@@ -1,0 +1,69 @@
+package com.example.askme.domain;
+
+import com.example.askme.domain.constant.ContentStatus;
+import com.example.askme.domain.constant.SolveState;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Article extends AuditingFields {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    @JoinColumn(name = "userId")
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    private UserAccount userAccount;
+
+    @Setter
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Setter
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @Enumerated(value = EnumType.STRING)
+    private SolveState state;
+
+    @Enumerated(value = EnumType.STRING)
+    private ContentStatus status;
+
+    @Setter
+    private String imageUrl;
+
+    @ColumnDefault("0")
+    private long viewCount = 0;
+
+    @ColumnDefault("0")
+    private long likeCount = 0;
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
+    private final List<ArticleComment> articleComments = new ArrayList<>();
+
+    private Article(UserAccount userAccount, String title, String content, SolveState state, ContentStatus status, String imageUrl, int viewCount, int likeCount) {
+        this.userAccount = userAccount;
+        this.title = title;
+        this.content = content;
+        this.state = state;
+        this.status = status;
+        this.imageUrl = imageUrl;
+        this.viewCount = viewCount;
+        this.likeCount = likeCount;
+    }
+
+    public static Article createArticle(UserAccount userAccount, String title, String content, SolveState state, ContentStatus status, String imageUrl, int viewCount, int likeCount) {
+        return new Article(userAccount, title, content, state, status, imageUrl, viewCount, likeCount);
+    }
+}

--- a/src/main/java/com/example/askme/domain/ArticleComment.java
+++ b/src/main/java/com/example/askme/domain/ArticleComment.java
@@ -1,0 +1,53 @@
+package com.example.askme.domain;
+
+import com.example.askme.domain.constant.ContentStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleComment extends AuditingFields {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Article article;
+
+    @Setter
+    @JoinColumn(name = "userId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private UserAccount userAccount;
+
+    @Enumerated(value = EnumType.STRING)
+    private ContentStatus status;
+
+    @Setter
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @Setter
+    private String imageUrl;
+
+    @ColumnDefault("0")
+    private long likeCount = 0;
+
+    private ArticleComment(Article article, UserAccount userAccount, ContentStatus status, String content, String imageUrl, int likeCount) {
+        this.article = article;
+        this.userAccount = userAccount;
+        this.status = status;
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.likeCount = likeCount;
+    }
+
+    public static ArticleComment createArticleComment(Article article, UserAccount userAccount, String content, String imageUrl) {
+        return new ArticleComment(article, userAccount, ContentStatus.PUBLISH, content, imageUrl, 0);
+    }
+}

--- a/src/main/java/com/example/askme/domain/AuditingFields.java
+++ b/src/main/java/com/example/askme/domain/AuditingFields.java
@@ -1,0 +1,35 @@
+package com.example.askme.domain;
+
+import lombok.Getter;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class AuditingFields {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    protected LocalDateTime modifiedAt;
+
+    @CreatedBy
+    @Column(nullable = false, updatable = false)
+    protected String createdBy;
+
+    @LastModifiedBy
+    @Column(nullable = false)
+    protected String modifiedBy;
+}

--- a/src/main/java/com/example/askme/domain/UserAccount.java
+++ b/src/main/java/com/example/askme/domain/UserAccount.java
@@ -1,0 +1,53 @@
+package com.example.askme.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserAccount extends AuditingFields {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Setter
+    @Column(nullable = false, length = 50)
+    private String userId;
+
+    @Setter
+    @Column(nullable = false)
+    private String userPassword;
+
+    @Setter
+    @Column(nullable = false, length = 100)
+    private String nickname;
+
+    @Setter
+    @Column(nullable = false, length = 100)
+    private String email;
+
+    @Column
+    @ColumnDefault("0")
+    private long questionCount = 0;
+
+    @Setter
+    private String imageUrl;
+
+    private UserAccount(String userId, String nickname, String email, int questionCount, String imageUrl) {
+        this.userId = userId;
+        this.nickname = nickname;
+        this.email = email;
+        this.questionCount = questionCount;
+        this.imageUrl = imageUrl;
+    }
+
+    public static UserAccount createUser(String userId, String nickname, String email, int questionCount, String imageUrl) {
+        return new UserAccount(userId, nickname, email, questionCount, imageUrl);
+    }
+}

--- a/src/main/java/com/example/askme/domain/constant/ContentStatus.java
+++ b/src/main/java/com/example/askme/domain/constant/ContentStatus.java
@@ -1,0 +1,11 @@
+package com.example.askme.domain.constant;
+
+public enum ContentStatus {
+    PUBLISH,  // 게시글, 댓글이 최초로 공개된 상태
+    EDITED,   // 게시글, 댓글이 수정된 상태
+    DELETED;  // 게시글, 댓글이 삭제 되어 보이지 않는 상태
+
+    public String getStatus() {
+        return this.name();
+    }
+}

--- a/src/main/java/com/example/askme/domain/constant/SolveState.java
+++ b/src/main/java/com/example/askme/domain/constant/SolveState.java
@@ -1,0 +1,10 @@
+package com.example.askme.domain.constant;
+
+public enum SolveState {
+
+    SOLVED, NOT_SOLVED_YET; // 게시글 해결, 미해결
+
+    public String getStatus() {
+        return this.name();
+    }
+}


### PR DESCRIPTION
## 개요
close: https://github.com/JongMinCh0i/askme/issues/3

## 작업 요약
Q&A 서비스의 대표 도메인(유저, 게시글, 댓글, 시간, 유저 Auditing) 구현

## 작업 내용
- Spring Data JPA 를 사용해서 각 엔티티 간의 관계를 정의 및 구현 

  ###  게시글
    -  게시글 → 유저 (단방향, ManyToOne)
    -  게시글 ↔ 댓글 (양방향, OneToMany, ManyToOne)

  ###  댓글
    -  댓글 → 유저 (단방향, ManyToOne)
    
  ###  유저
    - 연관관계 없음

- 게시글, 댓글 상태를 정의하는 열거형 구현 
  - 채택, 미채택 
  - 작성, 수정, 삭제
