### PR TITLE
프로젝트 리팩토링 (예외 처리, 에러코드, 도메인 FK 제약 조건 설정, 연관관계 편의 메서드 작성) 

### DIFF
--- a/src/main/java/com/example/askme/api/controller/account/request/AccountCreateRequest.java
+++ b/src/main/java/com/example/askme/api/controller/account/request/AccountCreateRequest.java
@@ -16,15 +16,15 @@ import lombok.NoArgsConstructor;
 public class AccountCreateRequest {
 
     @NotEmpty(message = "닉네임은 필수입니다.")
-    @Size(max = 50)
+    @Size(max = 50 , message = "닉네임은 50자 이하로 입력해주세요.")
     private String nickname;
 
     @NotEmpty(message = "로그인 Id는 필수입니다.")
-    @Size(max = 50)
+    @Size(max = 50, message = "로그인 Id는 50자 이하로 입력해주세요.")
     private String userId;
 
+    @Size(max = 50, message = "이메일은 50자 이하로 입력해주세요.")
     @Email(message = "이메일 형식이 아닙니다.")
-    @Size(max = 50)
     @NotEmpty(message = "이메일은 필수입니다.")
     private String email;
 

--- a/src/main/java/com/example/askme/api/controller/account/request/AccountCreateRequest.java
+++ b/src/main/java/com/example/askme/api/controller/account/request/AccountCreateRequest.java
@@ -4,11 +4,15 @@ import com.example.askme.api.service.account.request.AccountServiceRequest;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class AccountCreateRequest {
 
     @NotEmpty(message = "닉네임은 필수입니다.")

--- a/src/main/java/com/example/askme/api/service/account/request/AccountServiceRequest.java
+++ b/src/main/java/com/example/askme/api/service/account/request/AccountServiceRequest.java
@@ -1,5 +1,6 @@
 package com.example.askme.api.service.account.request;
 
+import com.example.askme.common.constant.MemberType;
 import com.example.askme.dao.account.Account;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,6 +30,7 @@ public class AccountServiceRequest {
         return Account.createUser(
                 userId,
                 password,
+                MemberType.QUESTIONER,
                 nickname,
                 email,
                 imageUrl,

--- a/src/main/java/com/example/askme/api/service/account/request/AccountServiceRequest.java
+++ b/src/main/java/com/example/askme/api/service/account/request/AccountServiceRequest.java
@@ -1,10 +1,11 @@
 package com.example.askme.api.service.account.request;
 
-import com.example.askme.common.constant.MemberType;
 import com.example.askme.dao.account.Account;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import static com.example.askme.common.constant.Role.*;
 
 @Getter
 @NoArgsConstructor
@@ -30,7 +31,7 @@ public class AccountServiceRequest {
         return Account.createUser(
                 userId,
                 password,
-                MemberType.QUESTIONER,
+                QUESTIONER,
                 nickname,
                 email,
                 imageUrl,

--- a/src/main/java/com/example/askme/api/service/account/response/AccountServiceResponse.java
+++ b/src/main/java/com/example/askme/api/service/account/response/AccountServiceResponse.java
@@ -1,6 +1,6 @@
 package com.example.askme.api.service.account.response;
 
-import com.example.askme.common.constant.MemberType;
+import com.example.askme.common.constant.Role;
 import com.example.askme.dao.account.Account;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,16 +15,16 @@ public class AccountServiceResponse {
     private String nickname;
     private String email;
     private long questionCount;
-    private MemberType memberType;
+    private Role role;
     private String imageUrl;
 
     @Builder
-    private AccountServiceResponse(Long id, String userId, String nickname, MemberType memberType, String email, long questionCount, String imageUrl, LocalDateTime createdAt, LocalDateTime updatedAt, Account createdBy) {
+    private AccountServiceResponse(Long id, String userId, String nickname, Role role, String email, long questionCount, String imageUrl, LocalDateTime createdAt, LocalDateTime updatedAt, Account createdBy) {
         this.id = id;
         this.userId = userId;
         this.nickname = nickname;
         this.email = email;
-        this.memberType = memberType;
+        this.role = role;
         this.questionCount = questionCount;
         this.imageUrl = imageUrl;
     }
@@ -35,7 +35,7 @@ public class AccountServiceResponse {
                 .userId(account.getUserId())
                 .nickname(account.getNickname())
                 .email(account.getEmail())
-                .memberType(account.getMemberType())
+                .role(account.getRole())
                 .questionCount(account.getQuestionCount())
                 .imageUrl(account.getImageUrl())
                 .build();

--- a/src/main/java/com/example/askme/api/service/account/response/AccountServiceResponse.java
+++ b/src/main/java/com/example/askme/api/service/account/response/AccountServiceResponse.java
@@ -1,5 +1,6 @@
 package com.example.askme.api.service.account.response;
 
+import com.example.askme.common.constant.MemberType;
 import com.example.askme.dao.account.Account;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,17 +15,18 @@ public class AccountServiceResponse {
     private String nickname;
     private String email;
     private long questionCount;
+    private MemberType memberType;
     private String imageUrl;
 
     @Builder
-    private AccountServiceResponse(Long id, String userId, String nickname, String email, long questionCount, String imageUrl, LocalDateTime createdAt, LocalDateTime updatedAt, Account createdBy) {
+    private AccountServiceResponse(Long id, String userId, String nickname, MemberType memberType, String email, long questionCount, String imageUrl, LocalDateTime createdAt, LocalDateTime updatedAt, Account createdBy) {
         this.id = id;
         this.userId = userId;
         this.nickname = nickname;
         this.email = email;
+        this.memberType = memberType;
         this.questionCount = questionCount;
         this.imageUrl = imageUrl;
-
     }
 
     public static AccountServiceResponse of(Account account) {
@@ -33,6 +35,7 @@ public class AccountServiceResponse {
                 .userId(account.getUserId())
                 .nickname(account.getNickname())
                 .email(account.getEmail())
+                .memberType(account.getMemberType())
                 .questionCount(account.getQuestionCount())
                 .imageUrl(account.getImageUrl())
                 .build();

--- a/src/main/java/com/example/askme/api/service/article/ArticleService.java
+++ b/src/main/java/com/example/askme/api/service/article/ArticleService.java
@@ -26,13 +26,13 @@ public class ArticleService {
     @Transactional
     public ArticleServiceResponse saveArticle(ArticleServiceRequest requestArticle) {
         Account account = accountRepository.findById(requestArticle.getAccountId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.ACCOUNT_NOT_FOUND, "해당 계정이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ACCOUNT_NOT_FOUND, "계정 ID " + requestArticle.getAccountId() + "에 해당하는 작성자가 존재하지 않습니다."));
         return ArticleServiceResponse.of(articleRepository.save(requestArticle.toEntity(account)));
     }
 
     public ArticleServiceResponse findById(Long id) {
         Article article = articleRepository.findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "존재하지 않는 게시글 입니다."));
         return ArticleServiceResponse.of(article);
     }
 
@@ -45,7 +45,7 @@ public class ArticleService {
     @Transactional
     public ArticleServiceResponse updateArticle(Long id, ArticleServiceRequest serviceRequest) {
         Article article = articleRepository.findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "수정할 게시글을 찾을 수 없습니다."));
 
         article.update(serviceRequest.getTitle(), serviceRequest.getContent());
         return ArticleServiceResponse.of(article);
@@ -54,7 +54,7 @@ public class ArticleService {
     @Transactional
     public ArticleServiceResponse deleteArticle(Long id) {
         Article article = articleRepository.findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "삭제할 게시글을 찾을 수 없습니다."));
 
         articleRepository.delete(article);
         return ArticleServiceResponse.of(article);
@@ -63,7 +63,7 @@ public class ArticleService {
     @Transactional
     public ArticleServiceResponse likeArticle(Long id) {
         Article article = articleRepository.findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "존재하지 않는 게시글 입니다"));
 
         article.increaseLikeCount();
         return ArticleServiceResponse.of(article);
@@ -72,11 +72,9 @@ public class ArticleService {
     @Transactional
     public ArticleServiceResponse dislikeArticle(Long id) {
         Article article = articleRepository.findById(id)
-                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "존재하지 않는 게시글 입니다"));
 
         article.decreaseLikeCount();
-
-
         return ArticleServiceResponse.of(article);
     }
 }

--- a/src/main/java/com/example/askme/api/service/article/ArticleService.java
+++ b/src/main/java/com/example/askme/api/service/article/ArticleService.java
@@ -2,7 +2,8 @@ package com.example.askme.api.service.article;
 
 import com.example.askme.api.service.article.request.ArticleServiceRequest;
 import com.example.askme.api.service.article.response.ArticleServiceResponse;
-import com.example.askme.common.exception.BusinessException;
+import com.example.askme.common.error.ErrorCode;
+import com.example.askme.common.error.exception.BusinessException;
 import com.example.askme.dao.account.Account;
 import com.example.askme.dao.account.AccountRepository;
 import com.example.askme.dao.article.Article;
@@ -23,15 +24,15 @@ public class ArticleService {
     private final AccountRepository accountRepository;
 
     @Transactional
-    public ArticleServiceResponse saveArticle (ArticleServiceRequest requestArticle) {
+    public ArticleServiceResponse saveArticle(ArticleServiceRequest requestArticle) {
         Account account = accountRepository.findById(requestArticle.getAccountId())
-                .orElseThrow(() -> new BusinessException("해당 계정이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ACCOUNT_NOT_FOUND, "해당 계정이 존재하지 않습니다."));
         return ArticleServiceResponse.of(articleRepository.save(requestArticle.toEntity(account)));
     }
 
     public ArticleServiceResponse findById(Long id) {
         Article article = articleRepository.findById(id)
-                .orElseThrow(() -> new BusinessException("해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "해당 게시글이 존재하지 않습니다."));
         return ArticleServiceResponse.of(article);
     }
 
@@ -44,7 +45,7 @@ public class ArticleService {
     @Transactional
     public ArticleServiceResponse updateArticle(Long id, ArticleServiceRequest serviceRequest) {
         Article article = articleRepository.findById(id)
-                .orElseThrow(() -> new BusinessException("해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "해당 게시글이 존재하지 않습니다."));
 
         article.update(serviceRequest.getTitle(), serviceRequest.getContent());
         return ArticleServiceResponse.of(article);
@@ -53,7 +54,7 @@ public class ArticleService {
     @Transactional
     public ArticleServiceResponse deleteArticle(Long id) {
         Article article = articleRepository.findById(id)
-                .orElseThrow(() -> new BusinessException("해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "해당 게시글이 존재하지 않습니다."));
 
         articleRepository.delete(article);
         return ArticleServiceResponse.of(article);
@@ -62,7 +63,7 @@ public class ArticleService {
     @Transactional
     public ArticleServiceResponse likeArticle(Long id) {
         Article article = articleRepository.findById(id)
-                .orElseThrow(() -> new BusinessException("해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "해당 게시글이 존재하지 않습니다."));
 
         article.increaseLikeCount();
         return ArticleServiceResponse.of(article);
@@ -71,7 +72,7 @@ public class ArticleService {
     @Transactional
     public ArticleServiceResponse dislikeArticle(Long id) {
         Article article = articleRepository.findById(id)
-                .orElseThrow(() -> new BusinessException("해당 게시글이 존재하지 않습니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.ARTICLE_NOT_FOUND, "해당 게시글이 존재하지 않습니다."));
 
         article.decreaseLikeCount();
 

--- a/src/main/java/com/example/askme/common/constant/LoginType.java
+++ b/src/main/java/com/example/askme/common/constant/LoginType.java
@@ -1,0 +1,5 @@
+package com.example.askme.common.constant;
+
+public enum LoginType {
+    KAKAO, NAVER, GOOGLE
+}

--- a/src/main/java/com/example/askme/common/constant/MemberType.java
+++ b/src/main/java/com/example/askme/common/constant/MemberType.java
@@ -1,6 +1,0 @@
-package com.example.askme.common.constant;
-
-public enum MemberType {
-    QUESTIONER, // 질문자
-    ANSWERER;   // 답변자
-}

--- a/src/main/java/com/example/askme/common/constant/MemberType.java
+++ b/src/main/java/com/example/askme/common/constant/MemberType.java
@@ -1,0 +1,6 @@
+package com.example.askme.common.constant;
+
+public enum MemberType {
+    QUESTIONER, // 질문자
+    ANSWERER;   // 답변자
+}

--- a/src/main/java/com/example/askme/common/constant/Role.java
+++ b/src/main/java/com/example/askme/common/constant/Role.java
@@ -1,0 +1,5 @@
+package com.example.askme.common.constant;
+
+public enum Role {
+    QUESTIONER, ANSWERER
+}

--- a/src/main/java/com/example/askme/common/error/ErrorCode.java
+++ b/src/main/java/com/example/askme/common/error/ErrorCode.java
@@ -1,0 +1,28 @@
+package com.example.askme.common.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    //계정
+    ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, "001", "해당 계정이 존재하지 않습니다."),
+
+    //게시글
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "002", "해당 게시글이 존재하지 않습니다."),
+
+    //인증
+    TOKEN_NOT_VALID(HttpStatus.UNAUTHORIZED, "A001", "토큰이 유효하지 않습니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "A002", "토큰이 만료되었습니다.");
+
+    private HttpStatus httpStatus;
+    private String errorCode;
+    private String message;
+
+    ErrorCode(HttpStatus httpStatus, String errorCode, String message) {
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/askme/common/error/exception/BusinessException.java
+++ b/src/main/java/com/example/askme/common/error/exception/BusinessException.java
@@ -1,0 +1,31 @@
+package com.example.askme.common.error.exception;
+
+import com.example.askme.common.error.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, Throwable cause) {
+        super(cause);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, String message, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/example/askme/common/error/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/example/askme/common/error/exception/GlobalExceptionAdvice.java
@@ -23,7 +23,7 @@ public class GlobalExceptionAdvice {
         log.error("[{}] Internal Server Error. message={}", errorId, e.getMessage(), e);
         return ResultResponse.fail(
                 String.format(
-                        "[%s] 서버 내부 오류가 발생했습니다", errorId)
+                        "[%s] 알 수 없는 에러가 발생했습니다", errorId)
         );
     }
 
@@ -34,7 +34,7 @@ public class GlobalExceptionAdvice {
         log.error("[{}] Business Exception. message={}", errorId, e.getMessage(), e);
         return ResultResponse.fail(
                 String.format(
-                        "[%s] 에러 코드: %s 알 수 없는 오류가 발생했습니다. 메시지: %s", errorId, e.getErrorCode(), e.getMessage())
+                        "[%s] 에러 코드: %s 에러 메시지 : %s", errorId, e.getErrorCode(), e.getMessage())
         );
     }
 

--- a/src/main/java/com/example/askme/common/error/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/com/example/askme/common/error/exception/GlobalExceptionAdvice.java
@@ -1,0 +1,57 @@
+package com.example.askme.common.error.exception;
+
+import com.example.askme.common.ResultResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionAdvice {
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler
+    protected ResultResponse<Void> handleInternalServerError(Exception e) {
+        String errorId = UUID.randomUUID().toString();
+        log.error("[{}] Internal Server Error. message={}", errorId, e.getMessage(), e);
+        return ResultResponse.fail(
+                String.format(
+                        "[%s] 서버 내부 오류가 발생했습니다", errorId)
+        );
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @ExceptionHandler(BusinessException.class)
+    protected ResultResponse<Void> handleBusinessException(BusinessException e) {
+        String errorId = UUID.randomUUID().toString();
+        log.error("[{}] Business Exception. message={}", errorId, e.getMessage(), e);
+        return ResultResponse.fail(
+                String.format(
+                        "[%s] 에러 코드: %s 알 수 없는 오류가 발생했습니다. 메시지: %s", errorId, e.getErrorCode(), e.getMessage())
+        );
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResultResponse<String> handleValidationExceptions(MethodArgumentNotValidException e) {
+        String errorId = UUID.randomUUID().toString();
+        List<String> errors = e.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+                .collect(Collectors.toList());
+
+        log.error("[{}] Validation error: {}", errorId, errors);
+
+        String errorMessage = String.format(
+                "[%s] 입력 값을 다시 확인해 주세요. 문제가 발생한 필드: %s",
+                errorId, String.join(", ", errors));
+
+        return ResultResponse.fail(errorMessage);
+    }
+}

--- a/src/main/java/com/example/askme/dao/AuditingEntity.java
+++ b/src/main/java/com/example/askme/dao/AuditingEntity.java
@@ -1,0 +1,23 @@
+package com.example.askme.dao;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class AuditingEntity extends AuditingTimeEntity {
+
+    @CreatedBy
+    @Column(updatable = false)
+    protected String createdBy;
+
+    @LastModifiedBy
+    protected String modifiedBy;
+}

--- a/src/main/java/com/example/askme/dao/AuditingTimeEntity.java
+++ b/src/main/java/com/example/askme/dao/AuditingTimeEntity.java
@@ -4,17 +4,15 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import java.time.LocalDateTime;
 
 @Getter
-@EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
-public abstract class AuditingFields {
+@EntityListeners(AuditingEntityListener.class)
+public abstract class AuditingTimeEntity {
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
@@ -23,12 +21,4 @@ public abstract class AuditingFields {
     @LastModifiedDate
     @Column(nullable = false)
     protected LocalDateTime modifiedAt;
-
-    @CreatedBy
-    @Column(nullable = false, updatable = false)
-    protected String createdBy;
-
-    @LastModifiedBy
-    @Column(nullable = false)
-    protected String modifiedBy;
 }

--- a/src/main/java/com/example/askme/dao/account/Account.java
+++ b/src/main/java/com/example/askme/dao/account/Account.java
@@ -1,5 +1,7 @@
 package com.example.askme.dao.account;
 
+import com.example.askme.common.constant.MemberType;
+import com.example.askme.dao.AuditingTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
@@ -7,7 +9,7 @@ import org.hibernate.annotations.ColumnDefault;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Account {
+public class Account extends AuditingTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -20,6 +22,10 @@ public class Account {
     @Setter
     @Column(nullable = false)
     private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MemberType memberType;
 
     @Setter
     @Column(nullable = false, length = 100)
@@ -41,16 +47,17 @@ public class Account {
     private String imageUrl;
 
     @Builder
-    private Account(String userId, String password, String nickname, String email, String imageUrl, long questionCount) {
+    private Account(String userId, String password, MemberType memberType, String nickname, String email, String imageUrl, long questionCount) {
         this.userId = userId;
         this.password = password;
         this.nickname = nickname;
+        this.memberType = memberType;
         this.email = email;
         this.imageUrl = imageUrl;
         this.questionCount = questionCount;
     }
 
-    public static Account createUser(String userId, String password, String nickname, String email, String imageUrl, long questionCount) {
-        return new Account(userId, password, nickname, email, imageUrl, questionCount);
+    public static Account createUser(String userId, String password, MemberType memberType, String nickname, String email, String imageUrl, long questionCount) {
+        return new Account(userId, password, memberType, nickname, email, imageUrl, questionCount);
     }
 }

--- a/src/main/java/com/example/askme/dao/account/Account.java
+++ b/src/main/java/com/example/askme/dao/account/Account.java
@@ -1,6 +1,6 @@
 package com.example.askme.dao.account;
 
-import com.example.askme.common.constant.MemberType;
+import com.example.askme.common.constant.Role;
 import com.example.askme.dao.AuditingTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -25,7 +25,7 @@ public class Account extends AuditingTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private MemberType memberType;
+    private Role role;
 
     @Setter
     @Column(nullable = false, length = 100)
@@ -47,17 +47,17 @@ public class Account extends AuditingTimeEntity {
     private String imageUrl;
 
     @Builder
-    private Account(String userId, String password, MemberType memberType, String nickname, String email, String imageUrl, long questionCount) {
+    private Account(String userId, String password, Role role, String nickname, String email, String imageUrl, long questionCount) {
         this.userId = userId;
         this.password = password;
         this.nickname = nickname;
-        this.memberType = memberType;
+        this.role = role;
         this.email = email;
         this.imageUrl = imageUrl;
         this.questionCount = questionCount;
     }
 
-    public static Account createUser(String userId, String password, MemberType memberType, String nickname, String email, String imageUrl, long questionCount) {
-        return new Account(userId, password, memberType, nickname, email, imageUrl, questionCount);
+    public static Account createUser(String userId, String password, Role role, String nickname, String email, String imageUrl, long questionCount) {
+        return new Account(userId, password, role, nickname, email, imageUrl, questionCount);
     }
 }

--- a/src/main/java/com/example/askme/dao/article/Article.java
+++ b/src/main/java/com/example/askme/dao/article/Article.java
@@ -63,7 +63,7 @@ public class Article extends AuditingTimeEntity {
         }
     }
 
-    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Comment> articleComments = new ArrayList<>();
 
     private Article(Account account, String title, String content, SolveState state, ContentStatus status, String imageUrl, long viewCount, long likeCount) {
@@ -85,4 +85,15 @@ public class Article extends AuditingTimeEntity {
         this.title = title;
         this.content = content;
     }
+
+    public void addComment(Comment comment) {
+        this.articleComments.add(comment);
+        comment.setArticle(this);
+    }
+
+    public void removeComment(Comment comment) {
+        this.articleComments.remove(comment);
+        comment.setArticle(null);
+    }
+
 }

--- a/src/main/java/com/example/askme/dao/article/Article.java
+++ b/src/main/java/com/example/askme/dao/article/Article.java
@@ -1,6 +1,6 @@
 package com.example.askme.dao.article;
 
-import com.example.askme.dao.AuditingFields;
+import com.example.askme.dao.AuditingTimeEntity;
 import com.example.askme.dao.comment.Comment;
 import com.example.askme.common.constant.ContentStatus;
 import com.example.askme.common.constant.SolveState;
@@ -15,7 +15,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Article extends AuditingFields {
+public class Article extends AuditingTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/askme/dao/comment/Comment.java
+++ b/src/main/java/com/example/askme/dao/comment/Comment.java
@@ -1,6 +1,6 @@
 package com.example.askme.dao.comment;
 
-import com.example.askme.dao.AuditingFields;
+import com.example.askme.dao.AuditingEntity;
 import com.example.askme.dao.article.Article;
 import com.example.askme.dao.account.Account;
 import com.example.askme.common.constant.ContentStatus;
@@ -14,7 +14,7 @@ import org.hibernate.annotations.ColumnDefault;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment extends AuditingFields {
+public class Comment extends AuditingEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/askme/dao/comment/Comment.java
+++ b/src/main/java/com/example/askme/dao/comment/Comment.java
@@ -20,7 +20,9 @@ public class Comment extends AuditingEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @Setter
+    @JoinColumn(name = "articleId")
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private Article article;
 
     @Setter

--- a/src/test/java/com/example/askme/api/controller/account/AccountControllerTest.java
+++ b/src/test/java/com/example/askme/api/controller/account/AccountControllerTest.java
@@ -3,7 +3,7 @@ package com.example.askme.api.controller.account;
 import com.example.askme.api.controller.account.request.AccountCreateRequest;
 import com.example.askme.api.service.account.AccountService;
 import com.example.askme.api.service.account.response.AccountServiceResponse;
-import com.example.askme.common.constant.MemberType;
+import com.example.askme.common.constant.Role;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,7 +50,7 @@ public class AccountControllerTest {
                 .email(request.getEmail())
                 .questionCount(0)
                 .imageUrl(null)
-                .memberType(MemberType.QUESTIONER)
+                .role(Role.QUESTIONER)
                 .build();
 
         given(accountService.signUp(any(AccountCreateRequest.class))).willReturn(response);
@@ -65,7 +65,7 @@ public class AccountControllerTest {
                 .andExpect(jsonPath("$.data.nickname").value("nickname"))
                 .andExpect(jsonPath("$.data.email").value("email@example.com"))
                 .andExpect(jsonPath("$.data.questionCount").value(0))
-                .andExpect(jsonPath("$.data.memberType").value("QUESTIONER"))
+                .andExpect(jsonPath("$.data.role").value("QUESTIONER"))
                 .andExpect(jsonPath("$.data.imageUrl").isEmpty());
     }
 }

--- a/src/test/java/com/example/askme/api/controller/account/AccountControllerTest.java
+++ b/src/test/java/com/example/askme/api/controller/account/AccountControllerTest.java
@@ -3,6 +3,7 @@ package com.example.askme.api.controller.account;
 import com.example.askme.api.controller.account.request.AccountCreateRequest;
 import com.example.askme.api.service.account.AccountService;
 import com.example.askme.api.service.account.response.AccountServiceResponse;
+import com.example.askme.common.constant.MemberType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,6 +50,7 @@ public class AccountControllerTest {
                 .email(request.getEmail())
                 .questionCount(0)
                 .imageUrl(null)
+                .memberType(MemberType.QUESTIONER)
                 .build();
 
         given(accountService.signUp(any(AccountCreateRequest.class))).willReturn(response);
@@ -63,6 +65,7 @@ public class AccountControllerTest {
                 .andExpect(jsonPath("$.data.nickname").value("nickname"))
                 .andExpect(jsonPath("$.data.email").value("email@example.com"))
                 .andExpect(jsonPath("$.data.questionCount").value(0))
+                .andExpect(jsonPath("$.data.memberType").value("QUESTIONER"))
                 .andExpect(jsonPath("$.data.imageUrl").isEmpty());
     }
 }


### PR DESCRIPTION
## 개요
close: https://github.com/JongMinCh0i/askme/issues/8

## 작업 요약
프로젝트 리팩토링 (예외 처리, 에러코드, 도메인 FK 제약 조건, 연관관계 편의 메서드 작성)

## 작업 내용
 ###  예외 처리
   -  전역 에외 처리 코드 작성(GlobalExceptionAdvice)
      - 입력값 에외(4xx), 내부 비지니스 에외(2xx), 그 외 서버 에외(5xx) ResponseStatus Code 설정
   -  Custom 에외(BusinessException) 작성 
 ###  에러 코드
   - 001(Account 예러 코드), 002(Article 에러 코드) 
   - A001, A002 (Token 만료, 유효성 검증 에러 코드)
 ###  도메인 FK 제약 조건, 연관관계 편의 메서드 작성 
   - orphanRemoval = true, optional = false 를 통해서 게시글과 댓글의 FK 관계 설정 
   - [게시글 추가,제거] 양방향 연관관계 편의 메서드 작성 
  