### PR TITLE
비동기 이미지 업로드 처리 개선

### DIFF
--- a/src/main/java/com/example/askme/api/service/file/FileStorageService.java
+++ b/src/main/java/com/example/askme/api/service/file/FileStorageService.java
@@ -1,11 +1,11 @@
 package com.example.askme.api.service.file;
 
-import com.amazonaws.services.s3.model.ObjectMetadata;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URL;
+import java.util.concurrent.CompletableFuture;
 
 public interface FileStorageService {
-    URL uploadFile(String fileName, InputStream inputStream, ObjectMetadata metadata) throws IOException;
+    CompletableFuture<URL> uploadFile(MultipartFile image) throws IOException;
 }

--- a/src/main/java/com/example/askme/api/service/file/S3FileStorageService.java
+++ b/src/main/java/com/example/askme/api/service/file/S3FileStorageService.java
@@ -7,17 +7,24 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.util.IOUtils;
 import com.example.askme.common.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 import static com.example.askme.common.error.ErrorCode.INVALID_AWS_CONNECTION;
 
+@Slf4j
 @Service
+@Async
 @RequiredArgsConstructor
 public class S3FileStorageService implements FileStorageService {
 
@@ -27,22 +34,52 @@ public class S3FileStorageService implements FileStorageService {
     private String bucketName;
 
     @Override
-    public URL uploadFile(String fileName, InputStream inputStream, ObjectMetadata metadata) throws IOException {
-        byte[] bytes = IOUtils.toByteArray(inputStream);
-        metadata.setContentLength(bytes.length);
-        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+    public CompletableFuture<URL> uploadFile(MultipartFile image) {
+        log.info("업로드 파일 이미지 이름 = {}", image.getOriginalFilename());
+        return CompletableFuture.supplyAsync(() -> {
+            log.info("이미지 업로드 시작, 이미지 이름 = {}", image.getOriginalFilename());
+            String originalFilename = image.getOriginalFilename();
+            String extension = originalFilename.substring(originalFilename.lastIndexOf(".") + 1);
+            String fileName = UUID.randomUUID().toString().substring(0, 10) + originalFilename;
 
-        try {
-            PutObjectRequest putObjectRequest =
-                    new PutObjectRequest(bucketName, fileName, byteArrayInputStream, metadata)
-                            .withCannedAcl(CannedAccessControlList.PublicRead);
-            amazonS3Client.putObject(putObjectRequest);
-        } catch (Exception e) {
-            throw new BusinessException(INVALID_AWS_CONNECTION);
-        } finally {
-            byteArrayInputStream.close();
-        }
+            InputStream inputStream = null;
 
-        return amazonS3Client.getUrl(bucketName, fileName);
+            try {
+                inputStream = image.getInputStream();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType("image/" + extension);
+
+            byte[] bytes = null;
+
+            try {
+                bytes = IOUtils.toByteArray(inputStream);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            metadata.setContentLength(bytes.length);
+            ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+            try {
+                PutObjectRequest putObjectRequest = new PutObjectRequest(bucketName, fileName, byteArrayInputStream, metadata).withCannedAcl(CannedAccessControlList.PublicRead);
+                amazonS3Client.putObject(putObjectRequest);
+            } catch (Exception e) {
+                throw new BusinessException(INVALID_AWS_CONNECTION);
+            } finally {
+                try {
+                    byteArrayInputStream.close();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            URL url = amazonS3Client.getUrl(bucketName, fileName);
+            log.info("이미지 업로드 완료, 이미지 URL = {}", url);
+            return url;
+        });
     }
 }


### PR DESCRIPTION
## 개요
close: https://github.com/JongMinCh0i/askme/issues/30

## 작업 요약
여러 건의 이미지를 업로드할 때 단일 쓰레드인 [nio-8080-exec-2]에서 처리되어 성능 문제가 발생하는 문제를 식별
@Async 메서드를 다른 메서드 내부에서 호출하고, CompletableFuture의 join()을 사용함으로써 동기화 문제가 발생하는 문제를 해결함

## To do List

비동기 메서드 내부에서 CompletableFuture를 사용하는 대신, 비동기 메서드 호출 결과를 CompletableFuture로 반환하도록 수정
반환된 CompletableFuture를 모아서 join() 메서드로 최종 결과를 처리하여 이미지를 비동기로 처리할 수 있도록 개선하였고 이를 로그로 확인함 


<img width="635" alt="스크린샷 2024-07-22 오후 10 40 00" src="https://github.com/user-attachments/assets/aba431a2-dd07-402f-8783-65c43b06cc1c">

